### PR TITLE
Update test-and-release.yml - add node 20.x to testmatrix

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
Node 20.x is released since some time and at active LTS now.  So all adapters should be tested with node 20.x too.
Please merge PR. If any problems arise with node 20 its OK to remove node 20 tests for now but create a issue stating the problem and try to fix ist as soon as your time allows.